### PR TITLE
New line-spacing feature 

### DIFF
--- a/LinePress/LinePress.csproj
+++ b/LinePress/LinePress.csproj
@@ -26,6 +26,10 @@
     <RootNamespace>LinePress</RootNamespace>
     <AssemblyName>LinePress</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+	  <!-- The following three lines start the extension with devenv as external program in the experimental hive. see https://stackoverflow.com/a/30714367/2207482 -->
+	<StartAction>Program</StartAction>
+	<StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+	<StartArguments>/rootsuffix Exp</StartArguments>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>

--- a/LinePress/LinePress.csproj
+++ b/LinePress/LinePress.csproj
@@ -26,10 +26,10 @@
     <RootNamespace>LinePress</RootNamespace>
     <AssemblyName>LinePress</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-	  <!-- The following three lines start the extension with devenv as external program in the experimental hive. see https://stackoverflow.com/a/30714367/2207482 -->
-	<StartAction>Program</StartAction>
-	<StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
-	<StartArguments>/rootsuffix Exp</StartArguments>
+    <!-- The following three lines start the extension with devenv as external program in the experimental hive. see https://stackoverflow.com/a/30714367/2207482 -->
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
@@ -58,6 +58,7 @@
     <Compile Include="LinePressPackage.cs" />
     <Compile Include="LineTransformation\LinePressTransformSource.cs" />
     <Compile Include="LineTransformation\LinePressTransformSourceProvider.cs" />
+    <Compile Include="Options\BoolInverterConverter.cs" />
     <Compile Include="Options\Infrastructure\ISettings.cs" />
     <Compile Include="Options\OptionsPage.cs">
       <SubType>Component</SubType>
@@ -134,6 +135,7 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>

--- a/LinePress/LineTransformation/LinePressTransformSource.cs
+++ b/LinePress/LineTransformation/LinePressTransformSource.cs
@@ -10,10 +10,8 @@ namespace LinePress
       private LineTransform defaultTransform;
       private LineTransform spacedTransform;
 
-      private LineTransform emptyLineTransform;
       private LineTransform spacedEmptyLineTransform;
 
-      private LineTransform customTokensTransform;
       private LineTransform spacedCustomTokensTransform;
 
       private readonly IWpfTextView textView;
@@ -45,9 +43,7 @@ namespace LinePress
          var bottomSpace = (double)settings.LineSpacing;
          defaultTransform = new LineTransform(0d, 0d, 1d);
          spacedTransform = new LineTransform(0d, bottomSpace, 1d);
-         emptyLineTransform = new LineTransform(0d, 0d, (100d - settings.EmptyLineScale) / 100d);
          spacedEmptyLineTransform = new LineTransform(0d, bottomSpace, (100d - settings.EmptyLineScale) / 100d);
-         customTokensTransform = new LineTransform(0d, 0d, (100d - settings.CustomTokensScale) / 100d);
          spacedCustomTokensTransform = new LineTransform(0d, bottomSpace, (100d - settings.CustomTokensScale) / 100d);
       }
 

--- a/LinePress/LineTransformation/LinePressTransformSource.cs
+++ b/LinePress/LineTransformation/LinePressTransformSource.cs
@@ -41,10 +41,12 @@ namespace LinePress
 
       private void SetTransforms()
       {
-         var bottomSpace = settings.EmSpacingUsed 
-                ? settings.LineSpacing * textView.TextViewLines.FirstVisibleLine.TextHeight
-                : settings.LineSpacing;
          defaultTransform = new LineTransform(0d, 0d, 1d);
+         
+         var bottomSpace = settings.EmSpacingUsed 
+            ? settings.LineSpacing * textView?.TextViewLines?.FirstVisibleLine?.TextHeight ?? 10d
+            : settings.LineSpacing;
+
          spacedTransform = new LineTransform(0d, bottomSpace, 1d);
          emptyLineTransform = new LineTransform(0d, bottomSpace, (100d - settings.EmptyLineScale) / 100d);
          customTokensTransform = new LineTransform(0d, bottomSpace, (100d - settings.CustomTokensScale) / 100d);

--- a/LinePress/LineTransformation/LinePressTransformSource.cs
+++ b/LinePress/LineTransformation/LinePressTransformSource.cs
@@ -6,7 +6,7 @@ namespace LinePress
 {
    public class LinePressTransformSource : ILineTransformSource
    {
-      private readonly LineTransform defaultTransform = new LineTransform(0d, 0d, 1d);
+      private LineTransform defaultTransform;
 
       private LineTransform emptyLineTransform;
       private LineTransform customTokensTransform;
@@ -37,8 +37,9 @@ namespace LinePress
 
       private void SetTransforms()
       {
-         emptyLineTransform = new LineTransform(0d, 0d, (100d - settings.EmptyLineScale) / 100d);
-         customTokensTransform = new LineTransform(0d, 0d, (100d - settings.CustomTokensScale) / 100d);
+         defaultTransform = new LineTransform(settings.TopSpace, settings.BottomSpace, 1d);
+         emptyLineTransform = new LineTransform(settings.TopSpace, settings.BottomSpace, (100d - settings.EmptyLineScale) / 100d);
+         customTokensTransform = new LineTransform(settings.TopSpace, settings.BottomSpace, (100d - settings.CustomTokensScale) / 100d);
       }
 
       public static LinePressTransformSource Create(IWpfTextView view)

--- a/LinePress/LineTransformation/LinePressTransformSource.cs
+++ b/LinePress/LineTransformation/LinePressTransformSource.cs
@@ -37,9 +37,10 @@ namespace LinePress
 
       private void SetTransforms()
       {
-         defaultTransform = new LineTransform(settings.TopSpace, settings.BottomSpace, 1d);
-         emptyLineTransform = new LineTransform(settings.TopSpace, settings.BottomSpace, (100d - settings.EmptyLineScale) / 100d);
-         customTokensTransform = new LineTransform(settings.TopSpace, settings.BottomSpace, (100d - settings.CustomTokensScale) / 100d);
+         var bottomSpace = (double) settings.LineSpacing;
+         defaultTransform = new LineTransform(0d, bottomSpace, 1d);
+         emptyLineTransform = new LineTransform(0d, bottomSpace, (100d - settings.EmptyLineScale) / 100d);
+         customTokensTransform = new LineTransform(0d, bottomSpace, (100d - settings.CustomTokensScale) / 100d);
       }
 
       public static LinePressTransformSource Create(IWpfTextView view)

--- a/LinePress/Options/BoolInverterConverter.cs
+++ b/LinePress/Options/BoolInverterConverter.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Windows.Data;
+
+
+namespace LinePress.Options {
+    public class BoolInverterConverter : IValueConverter
+    {
+        #region IValueConverter Members
+
+        public object Convert(object value, Type targetType, object parameter,
+                              System.Globalization.CultureInfo culture)
+        {
+            if (value is bool) return !(bool) value;
+            return value;
+        }
+
+
+        public object ConvertBack(object value, Type targetType, object parameter,
+                                  System.Globalization.CultureInfo culture)
+        {
+            if (value is bool) return !(bool) value;
+            return value;
+        }
+
+        #endregion
+    }
+}

--- a/LinePress/Options/LinePressSettings.cs
+++ b/LinePress/Options/LinePressSettings.cs
@@ -15,9 +15,9 @@ namespace LinePress.Options
       private bool compressCustomTokens = true;
 
       // lineSpacing = topSpace + bottomSpace
-      private double lineSpacing = 0; 
-      private double topSpace = 0;
-      private double bottomSpace = 0;
+      private int lineSpacing = 0; 
+      //private double topSpace = 0;
+      //private double bottomSpace = 0;
       private int emptyLineScale = 50;
       private int customTokensScale = 25;
       
@@ -45,29 +45,30 @@ namespace LinePress.Options
          DeleteTokenCommand = new RelayCommand<string>(CanDeleteToken, t => CustomTokens.Remove(t));
       }
 
-      #endregion
+        #endregion
 
-      #region Settings Properties
+        #region Settings Properties
 
-      public double LineSpacing
+      [Setting]
+      public int LineSpacing
       {
          get { return lineSpacing; }
          set { SetField(ref lineSpacing, value); }
       }
 
-      [Setting]
-      public double TopSpace
-      {
-          get { return lineSpacing / 2; }
-          set { SetField(ref topSpace, value); }
-      }
+      //[Setting]
+      //public double TopSpace
+      //{
+      //    get { return lineSpacing / 2; }
+      //    set { SetField(ref topSpace, value); }
+      //}
 
-      [Setting]
-      public double BottomSpace
-      {
-         get { return lineSpacing / 2; }
-         set { SetField(ref bottomSpace, value); }
-      }
+      //[Setting]
+      //public double BottomSpace
+      //{
+      //   get { return lineSpacing / 2; }
+      //   set { SetField(ref bottomSpace, value); }
+      //}
 
       [Setting]
       public bool CompressEmptyLines

--- a/LinePress/Options/LinePressSettings.cs
+++ b/LinePress/Options/LinePressSettings.cs
@@ -14,10 +14,9 @@ namespace LinePress.Options
       private bool compressEmptyLines = true;
       private bool compressCustomTokens = true;
 
-      // lineSpacing = topSpace + bottomSpace
-      private int lineSpacing = 0; 
-      //private double topSpace = 0;
-      //private double bottomSpace = 0;
+      private int lineSpacing = 0;
+       private bool applySpacingToComments = false;
+
       private int emptyLineScale = 50;
       private int customTokensScale = 25;
       
@@ -47,7 +46,7 @@ namespace LinePress.Options
 
         #endregion
 
-        #region Settings Properties
+      #region Settings Properties
 
       [Setting]
       public int LineSpacing
@@ -56,19 +55,12 @@ namespace LinePress.Options
          set { SetField(ref lineSpacing, value); }
       }
 
-      //[Setting]
-      //public double TopSpace
-      //{
-      //    get { return lineSpacing / 2; }
-      //    set { SetField(ref topSpace, value); }
-      //}
-
-      //[Setting]
-      //public double BottomSpace
-      //{
-      //   get { return lineSpacing / 2; }
-      //   set { SetField(ref bottomSpace, value); }
-      //}
+       [Setting]
+       public bool ApplySpacingToComments
+       {
+           get { return applySpacingToComments; }
+           set { SetField(ref applySpacingToComments, value); }
+       }
 
       [Setting]
       public bool CompressEmptyLines

--- a/LinePress/Options/LinePressSettings.cs
+++ b/LinePress/Options/LinePressSettings.cs
@@ -14,8 +14,9 @@ namespace LinePress.Options
       private bool compressEmptyLines = true;
       private bool compressCustomTokens = true;
 
-      private int lineSpacing = 0;
-       private bool applySpacingToComments = false;
+      private bool emSpacingUsed = false;
+      private double lineSpacing = 0d;
+      private bool applySpacingToComments = false;
 
       private int emptyLineScale = 50;
       private int customTokensScale = 25;
@@ -49,18 +50,40 @@ namespace LinePress.Options
       #region Settings Properties
 
       [Setting]
-      public int LineSpacing
+      public bool EmSpacingUsed
+      {
+          get { return emSpacingUsed; }
+          set {
+              SetField(ref emSpacingUsed, value); 
+              OnPropertyChanged(nameof(SpacingMaxValue));
+              OnPropertyChanged(nameof(SpacingTickValue));
+              OnPropertyChanged(nameof(SpacingUnitLabel));
+          }
+      }
+
+      public bool PixelSpacingUsed
+      {
+          get { return !emSpacingUsed; }
+          set { SetField(ref emSpacingUsed, !value); }
+      }
+
+      public double SpacingMaxValue => EmSpacingUsed ? 2d : 20d;
+      public double SpacingTickValue => EmSpacingUsed ? 0.1d : 1d;
+      public string SpacingUnitLabel => EmSpacingUsed ? " em" : " pixel";
+
+      [Setting]
+      public double LineSpacing
       {
          get { return lineSpacing; }
          set { SetField(ref lineSpacing, value); }
       }
 
-       [Setting]
-       public bool ApplySpacingToComments
-       {
-           get { return applySpacingToComments; }
-           set { SetField(ref applySpacingToComments, value); }
-       }
+      [Setting]
+      public bool ApplySpacingToComments
+      {
+          get { return applySpacingToComments; }
+          set { SetField(ref applySpacingToComments, value); }
+      }
 
       [Setting]
       public bool CompressEmptyLines

--- a/LinePress/Options/LinePressSettings.cs
+++ b/LinePress/Options/LinePressSettings.cs
@@ -14,6 +14,10 @@ namespace LinePress.Options
       private bool compressEmptyLines = true;
       private bool compressCustomTokens = true;
 
+      // lineSpacing = topSpace + bottomSpace
+      private double lineSpacing = 0; 
+      private double topSpace = 0;
+      private double bottomSpace = 0;
       private int emptyLineScale = 50;
       private int customTokensScale = 25;
       
@@ -44,6 +48,26 @@ namespace LinePress.Options
       #endregion
 
       #region Settings Properties
+
+      public double LineSpacing
+      {
+         get { return lineSpacing; }
+         set { SetField(ref lineSpacing, value); }
+      }
+
+      [Setting]
+      public double TopSpace
+      {
+          get { return lineSpacing / 2; }
+          set { SetField(ref topSpace, value); }
+      }
+
+      [Setting]
+      public double BottomSpace
+      {
+         get { return lineSpacing / 2; }
+         set { SetField(ref bottomSpace, value); }
+      }
 
       [Setting]
       public bool CompressEmptyLines

--- a/LinePress/Options/LinePressSettings.cs
+++ b/LinePress/Options/LinePressSettings.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System;
 
+
 namespace LinePress.Options
 {
    public class LinePressSettings : ISettings, INotifyPropertyChanged
@@ -59,12 +60,6 @@ namespace LinePress.Options
               OnPropertyChanged(nameof(SpacingTickValue));
               OnPropertyChanged(nameof(SpacingUnitLabel));
           }
-      }
-
-      public bool PixelSpacingUsed
-      {
-          get { return !emSpacingUsed; }
-          set { SetField(ref emSpacingUsed, !value); }
       }
 
       public double SpacingMaxValue => EmSpacingUsed ? 2d : 20d;

--- a/LinePress/Options/OptionsPageControl.xaml
+++ b/LinePress/Options/OptionsPageControl.xaml
@@ -297,13 +297,54 @@
          <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+	        <RowDefinition Height="Auto" />
          </Grid.RowDefinitions>
 
          <StackPanel>
 
+	         <!--! Line Spacing-->
+	         <GroupBox
+		         Grid.Row="0"
+		         Width="370"
+		         Padding="5,5,0,0"
+		         HorizontalAlignment="Left"
+		         BorderThickness="1.5"
+		         Header="Default Line Spacing">
+
+		         <StackPanel Grid.Row="0" Margin="0,5,0,0">
+
+			         <!--! Amount of Line Spacing -->
+			         <StackPanel
+				         Margin="20,10"
+				         Orientation="Horizontal">
+				         <Slider
+					         x:Name="LineSpacingAmountSlider"
+					         Width="240"
+					         Height="30"
+					         IsSnapToTickEnabled="True"
+					         Maximum="1"
+					         Minimum="0"
+					         TickFrequency="0.05"
+					         TickPlacement="Both"
+					         Value="{Binding LineSpacing, Mode=TwoWay}" />
+
+				         <TextBlock
+					         Padding="5,2"
+					         VerticalAlignment="Center"
+					         Style="{StaticResource DisabledTextBlock}"
+					         TextAlignment="Center">
+
+					         <Run Text="{Binding Value, ElementName=LineSpacingAmountSlider}" /><Run Text="%" />
+				         </TextBlock>
+
+			         </StackPanel>
+		         </StackPanel>
+	         </GroupBox>
+
+
             <!--! Empty Lines Compression Controls-->
             <GroupBox
-               Grid.Row="0"
+               Grid.Row="1"
                Width="370"
                Padding="5,5,0,0"
                HorizontalAlignment="Left"
@@ -353,7 +394,7 @@
 
             <!--! Custom Tokens Compression Controls-->
             <GroupBox
-               Grid.Row="1"
+               Grid.Row="2"
                Width="370"
                Margin="0,10,0,0"
                Padding="5,5,0,0"

--- a/LinePress/Options/OptionsPageControl.xaml
+++ b/LinePress/Options/OptionsPageControl.xaml
@@ -1,512 +1,365 @@
-﻿<UserControl
-   x:Class="LinePress.Options.OptionsPageControl"
-   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-   Width="393"
-   Height="420"
-   mc:Ignorable="d">
+﻿<UserControl x:Class="LinePress.Options.OptionsPageControl" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" Width="393"
+             Height="420" mc:Ignorable="d">
 
-   <UserControl.Resources>
+	<UserControl.Resources>
 
-      <!--! Dim TextBlock when disabled-->
-      <Style x:Key="DisabledTextBlock" TargetType="TextBlock">
-         <Style.Triggers>
-            <Trigger Property="IsEnabled" Value="False">
-               <Setter Property="Foreground" Value="Gray" />
-            </Trigger>
-         </Style.Triggers>
-      </Style>
+		<!--  ! Dim TextBlock when disabled  -->
+		<Style x:Key="DisabledTextBlock" TargetType="TextBlock">
+			<Style.Triggers>
+				<Trigger Property="IsEnabled" Value="False">
+					<Setter Property="Foreground" Value="Gray" />
+				</Trigger>
+			</Style.Triggers>
+		</Style>
 
-      <!--! Animated Toggle Switch Style-->
-      <Style x:Key="AnimatedSwitch" TargetType="{x:Type ToggleButton}">
-         <Setter Property="Foreground" Value="Black" />
-         <Setter Property="Background" Value="#FAFAFB" />
-         <Setter Property="BorderBrush" Value="#EAEAEB" />
-         <Setter Property="Template">
-            <Setter.Value>
-               <ControlTemplate TargetType="ToggleButton">
-                  <Viewbox Stretch="Uniform">
-                     <Canvas
-                        Name="Layer_1"
-                        Canvas.Left="10"
-                        Canvas.Top="0"
-                        Width="20"
-                        Height="20">
-                        <Ellipse
-                           Canvas.Left="0"
-                           Width="20"
-                           Height="20"
-                           Fill="{TemplateBinding Background}"
-                           Stroke="{TemplateBinding BorderBrush}"
-                           StrokeThickness="0.5" />
-                        <Ellipse
-                           Canvas.Left="15"
-                           Width="20"
-                           Height="20"
-                           Fill="{TemplateBinding Background}"
-                           Stroke="{TemplateBinding BorderBrush}"
-                           StrokeThickness="0.5" />
-                        <Border
-                           Name="rect416927"
-                           Canvas.Left="10"
-                           Width="15"
-                           Height="20"
-                           Background="{TemplateBinding Background}"
-                           BorderBrush="{TemplateBinding BorderBrush}"
-                           BorderThickness="0,0.5,0,0.5" />
-                        <Ellipse
-                           x:Name="ellipse"
-                           Canvas.Left="0"
-                           Width="20"
-                           Height="20"
-                           Fill="White"
-                           Stroke="{TemplateBinding BorderBrush}"
-                           StrokeThickness="0.3">
-                           <Ellipse.RenderTransform>
-                              <TranslateTransform X="0" Y="0" />
-                           </Ellipse.RenderTransform>
-                           <Ellipse.BitmapEffect>
-                              <DropShadowBitmapEffect
-                                 Direction="270"
-                                 ShadowDepth="0.7"
-                                 Softness="0.1"
-                                 Color="#BBBBBB" />
-                           </Ellipse.BitmapEffect>
-                        </Ellipse>
-                     </Canvas>
-                  </Viewbox>
-                  <ControlTemplate.Triggers>
-                     <Trigger Property="IsChecked" Value="False">
-                        <Trigger.Setters>
-                           <Setter Property="Background" Value="#f94939" />
-                        </Trigger.Setters>
-                     </Trigger>
-                     <Trigger Property="IsChecked" Value="True">
-                        <Trigger.EnterActions>
-                           <BeginStoryboard>
-                              <Storyboard>
-                                 <ColorAnimation
-                                    Storyboard.TargetProperty="Background.Color"
-                                    To="#52D468"
-                                    Duration="0:0:0.2" />
-                                 <ColorAnimation
-                                    Storyboard.TargetProperty="BorderBrush.Color"
-                                    To="#41C955"
-                                    Duration="0:0:0.2" />
-                                 <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ellipse" Storyboard.TargetProperty="(Ellipse.RenderTransform).(TranslateTransform.X)">
-                                    <SplineDoubleKeyFrame KeyTime="0" Value="0" />
-                                    <SplineDoubleKeyFrame
-                                       KeySpline="0, 1, 0.6, 1"
-                                       KeyTime="0:0:0.4"
-                                       Value="15" />
-                                 </DoubleAnimationUsingKeyFrames>
-                              </Storyboard>
-                           </BeginStoryboard>
-                        </Trigger.EnterActions>
-                        <Trigger.ExitActions>
-                           <BeginStoryboard>
-                              <Storyboard>
-                                 <ColorAnimation
-                                    Storyboard.TargetProperty="Background.Color"
-                                    To="#f94939"
-                                    Duration="0:0:0.2" />
-                                 <ColorAnimation
-                                    Storyboard.TargetProperty="BorderBrush.Color"
-                                    To="#f94939"
-                                    Duration="0:0:0.2" />
-                                 <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ellipse" Storyboard.TargetProperty="(Ellipse.RenderTransform).(TranslateTransform.X)">
-                                    <SplineDoubleKeyFrame KeyTime="0" Value="15" />
-                                    <SplineDoubleKeyFrame
-                                       KeySpline="0, 0.5, 0.5, 1"
-                                       KeyTime="0:0:0.3"
-                                       Value="0" />
-                                 </DoubleAnimationUsingKeyFrames>
-                              </Storyboard>
-                           </BeginStoryboard>
-                        </Trigger.ExitActions>
-                     </Trigger>
-                  </ControlTemplate.Triggers>
-               </ControlTemplate>
-            </Setter.Value>
-         </Setter>
-      </Style>
+		<!--  ! Animated Toggle Switch Style  -->
+		<Style x:Key="AnimatedSwitch" TargetType="{x:Type ToggleButton}">
+			<Setter Property="Foreground" Value="Black" />
+			<Setter Property="Background" Value="#FAFAFB" />
+			<Setter Property="BorderBrush" Value="#EAEAEB" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ToggleButton">
+						<Viewbox Stretch="Uniform">
+							<Canvas Name="Layer_1" Canvas.Left="10" Canvas.Top="0"
+							        Width="20" Height="20">
+								<Ellipse Canvas.Left="0" Width="20" Height="20"
+								         Fill="{TemplateBinding Background}"
+								         Stroke="{TemplateBinding BorderBrush}"
+								         StrokeThickness="0.5" />
+								<Ellipse Canvas.Left="15" Width="20" Height="20"
+								         Fill="{TemplateBinding Background}"
+								         Stroke="{TemplateBinding BorderBrush}"
+								         StrokeThickness="0.5" />
+								<Border Name="rect416927" Canvas.Left="10" Width="15"
+								        Height="20"
+								        Background="{TemplateBinding Background}"
+								        BorderBrush="{TemplateBinding BorderBrush}"
+								        BorderThickness="0,0.5,0,0.5" />
+								<Ellipse x:Name="ellipse" Canvas.Left="0" Width="20"
+								         Height="20" Fill="White"
+								         Stroke="{TemplateBinding BorderBrush}"
+								         StrokeThickness="0.3">
+									<Ellipse.RenderTransform>
+										<TranslateTransform X="0" Y="0" />
+									</Ellipse.RenderTransform>
+									<Ellipse.BitmapEffect>
+										<DropShadowBitmapEffect Direction="270" ShadowDepth="0.7" Softness="0.1"
+										                        Color="#BBBBBB" />
+									</Ellipse.BitmapEffect>
+								</Ellipse>
+							</Canvas>
+						</Viewbox>
+						<ControlTemplate.Triggers>
+							<Trigger Property="IsChecked" Value="False">
+								<Trigger.Setters>
+									<Setter Property="Background" Value="#f94939" />
+								</Trigger.Setters>
+							</Trigger>
+							<Trigger Property="IsChecked" Value="True">
+								<Trigger.EnterActions>
+									<BeginStoryboard>
+										<Storyboard>
+											<ColorAnimation Storyboard.TargetProperty="Background.Color" To="#52D468" Duration="0:0:0.2" />
+											<ColorAnimation Storyboard.TargetProperty="BorderBrush.Color" To="#41C955" Duration="0:0:0.2" />
+											<DoubleAnimationUsingKeyFrames Storyboard.TargetName="ellipse" Storyboard.TargetProperty="(Ellipse.RenderTransform).(TranslateTransform.X)">
+												<SplineDoubleKeyFrame KeyTime="0" Value="0" />
+												<SplineDoubleKeyFrame KeySpline="0, 1, 0.6, 1" KeyTime="0:0:0.4" Value="15" />
+											</DoubleAnimationUsingKeyFrames>
+										</Storyboard>
+									</BeginStoryboard>
+								</Trigger.EnterActions>
+								<Trigger.ExitActions>
+									<BeginStoryboard>
+										<Storyboard>
+											<ColorAnimation Storyboard.TargetProperty="Background.Color" To="#f94939" Duration="0:0:0.2" />
+											<ColorAnimation Storyboard.TargetProperty="BorderBrush.Color" To="#f94939" Duration="0:0:0.2" />
+											<DoubleAnimationUsingKeyFrames Storyboard.TargetName="ellipse" Storyboard.TargetProperty="(Ellipse.RenderTransform).(TranslateTransform.X)">
+												<SplineDoubleKeyFrame KeyTime="0" Value="15" />
+												<SplineDoubleKeyFrame KeySpline="0, 0.5, 0.5, 1" KeyTime="0:0:0.3" Value="0" />
+											</DoubleAnimationUsingKeyFrames>
+										</Storyboard>
+									</BeginStoryboard>
+								</Trigger.ExitActions>
+							</Trigger>
+						</ControlTemplate.Triggers>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
 
-      <!--! Transparent Button Style-->
-      <Style x:Key="TransparentButton" TargetType="Button">
-         <Setter Property="OverridesDefaultStyle" Value="True" />
-         <Setter Property="Background" Value="Transparent" />
+		<!--  ! Transparent Button Style  -->
+		<Style x:Key="TransparentButton" TargetType="Button">
+			<Setter Property="OverridesDefaultStyle" Value="True" />
+			<Setter Property="Background" Value="Transparent" />
 
-         <Setter Property="Template">
-            <Setter.Value>
-               <ControlTemplate TargetType="{x:Type Button}">
-                  <Grid Background="{TemplateBinding Background}">
-                     <ContentPresenter
-                        x:Name="MyContentPresenter"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        Content="{TemplateBinding Content}" />
-                  </Grid>
-               </ControlTemplate>
-            </Setter.Value>
-         </Setter>
-      </Style>
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="{x:Type Button}">
+						<Grid Background="{TemplateBinding Background}">
+							<ContentPresenter x:Name="MyContentPresenter" HorizontalAlignment="Center" VerticalAlignment="Center"
+							                  Content="{TemplateBinding Content}" />
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
 
-      <!--! Add Token Button Style-->
-      <Style
-         x:Key="AddButton"
-         BasedOn="{StaticResource TransparentButton}"
-         TargetType="Button">
-         <Style.Triggers>
-            <Trigger Property="IsEnabled" Value="True">
-               <Setter Property="Foreground" Value="Green" />
-            </Trigger>
+		<!--  ! Add Token Button Style  -->
+		<Style x:Key="AddButton" BasedOn="{StaticResource TransparentButton}" TargetType="Button">
+			<Style.Triggers>
+				<Trigger Property="IsEnabled" Value="True">
+					<Setter Property="Foreground" Value="Green" />
+				</Trigger>
 
-            <Trigger Property="IsEnabled" Value="False">
-               <Setter Property="Background" Value="Transparent" />
-               <Setter Property="Foreground" Value="Gray" />
-            </Trigger>
+				<Trigger Property="IsEnabled" Value="False">
+					<Setter Property="Background" Value="Transparent" />
+					<Setter Property="Foreground" Value="Gray" />
+				</Trigger>
 
-            <Trigger Property="IsPressed" Value="True">
-               <Setter Property="Foreground" Value="Black" />
-            </Trigger>
+				<Trigger Property="IsPressed" Value="True">
+					<Setter Property="Foreground" Value="Black" />
+				</Trigger>
 
-            <Trigger Property="IsMouseOver" Value="True">
-               <Setter Property="Background" Value="#FFE7E7E7" />
-            </Trigger>
-         </Style.Triggers>
-      </Style>
+				<Trigger Property="IsMouseOver" Value="True">
+					<Setter Property="Background" Value="#FFE7E7E7" />
+				</Trigger>
+			</Style.Triggers>
+		</Style>
 
-      <!--! Remove Token Button Style-->
-      <Style
-         x:Key="RemoveButton"
-         BasedOn="{StaticResource TransparentButton}"
-         TargetType="Button">
-         <Style.Triggers>
-            <Trigger Property="IsEnabled" Value="True">
-               <Setter Property="Foreground" Value="Red" />
-            </Trigger>
+		<!--  ! Remove Token Button Style  -->
+		<Style x:Key="RemoveButton" BasedOn="{StaticResource TransparentButton}" TargetType="Button">
+			<Style.Triggers>
+				<Trigger Property="IsEnabled" Value="True">
+					<Setter Property="Foreground" Value="Red" />
+				</Trigger>
 
-            <Trigger Property="IsEnabled" Value="False">
-               <Setter Property="Background" Value="Transparent" />
-               <Setter Property="Foreground" Value="Gray" />
-            </Trigger>
+				<Trigger Property="IsEnabled" Value="False">
+					<Setter Property="Background" Value="Transparent" />
+					<Setter Property="Foreground" Value="Gray" />
+				</Trigger>
 
-            <Trigger Property="IsPressed" Value="True">
-               <Setter Property="Foreground" Value="Black" />
-            </Trigger>
-         </Style.Triggers>
-      </Style>
+				<Trigger Property="IsPressed" Value="True">
+					<Setter Property="Foreground" Value="Black" />
+				</Trigger>
+			</Style.Triggers>
+		</Style>
 
-      <!--! Icon of the Add Token Button-->
-      <Viewbox x:Key="AddButtonIcon">
-         <Grid>
-            <Grid
-               Width="30"
-               Height="25"
-               Visibility="Visible">
-               <Rectangle Name="Rect" Visibility="Visible" />
-            </Grid>
-            <Path
-               Width="23"
-               Height="23"
-               Margin="0,0,0,0"
-               Data="M12.126984,0L19.872009,0 19.872009,12.128 32,12.128 32,19.872999 19.872009,19.872999 19.872009,31.999 12.126984,31.999 12.126984,19.872999 0,19.872999 0,12.128 12.126984,12.128z"
-               Fill="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
-               RenderTransformOrigin="0.5,0.5"
-               Stretch="Uniform">
-               <Path.RenderTransform>
-                  <TransformGroup>
-                     <TransformGroup.Children>
-                        <RotateTransform Angle="0" />
-                        <ScaleTransform ScaleX=".6" ScaleY=".6" />
-                     </TransformGroup.Children>
-                  </TransformGroup>
-               </Path.RenderTransform>
-            </Path>
-         </Grid>
-      </Viewbox>
+		<!--  ! Icon of the Add Token Button  -->
+		<Viewbox x:Key="AddButtonIcon">
+			<Grid>
+				<Grid Width="30" Height="25" Visibility="Visible">
+					<Rectangle Name="Rect" Visibility="Visible" />
+				</Grid>
+				<Path Width="23" Height="23" Margin="0,0,0,0"
+				      Data="M12.126984,0L19.872009,0 19.872009,12.128 32,12.128 32,19.872999 19.872009,19.872999 19.872009,31.999 12.126984,31.999 12.126984,19.872999 0,19.872999 0,12.128 12.126984,12.128z"
+				      Fill="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+				      RenderTransformOrigin="0.5,0.5" Stretch="Uniform">
+					<Path.RenderTransform>
+						<TransformGroup>
+							<TransformGroup.Children>
+								<RotateTransform Angle="0" />
+								<ScaleTransform ScaleX=".6" ScaleY=".6" />
+							</TransformGroup.Children>
+						</TransformGroup>
+					</Path.RenderTransform>
+				</Path>
+			</Grid>
+		</Viewbox>
 
-      <!--! Icon of the Remove Token Button-->
-      <Viewbox x:Key="RemoveButtonIcon" />
+		<!--  ! Icon of the Remove Token Button  -->
+		<Viewbox x:Key="RemoveButtonIcon" />
 
-      <!--! Token List Item DataTemplate-->
-      <DataTemplate x:Key="TokenListItemTemplate">
-         <Border Margin="0,2">
-            <StackPanel>
-               <Grid>
-                  <Grid.ColumnDefinitions>
-                     <ColumnDefinition Width="*" />
-                     <ColumnDefinition Width="30" />
-                  </Grid.ColumnDefinitions>
+		<!--  ! Token List Item DataTemplate  -->
+		<DataTemplate x:Key="TokenListItemTemplate">
+			<Border Margin="0,2">
+				<StackPanel>
+					<Grid>
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="30" />
+						</Grid.ColumnDefinitions>
 
-                  <TextBlock
-                     x:Name="TokenField"
-                     Grid.Column="0"
-                     Padding="8,0,0,0"
-                     FontSize="16"
-                     FontWeight="SemiBold"
-                     Text="{Binding}" />
+						<TextBlock x:Name="TokenField" Grid.Column="0" Padding="8,0,0,0"
+						           FontSize="16" FontWeight="SemiBold"
+						           Text="{Binding}" />
 
-                  <Button
-                     Grid.Column="1"
-                     Height="25"
-                     Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=DataContext.DeleteTokenCommand}"
-                     CommandParameter="{Binding ElementName=TokenField, Path=Text}"
-                     Cursor="Hand"
-                     Style="{StaticResource RemoveButton}">
+						<Button Grid.Column="1" Height="25"
+						        Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=DataContext.DeleteTokenCommand}"
+						        CommandParameter="{Binding ElementName=TokenField, Path=Text}"
+						        Cursor="Hand"
+						        Style="{StaticResource RemoveButton}">
 
-                     <Button.Content>
-                        <Grid>
-                           <Grid
-                              Width="30"
-                              Height="25"
-                              Visibility="Collapsed" />
-                           <Path
-                              Width="23"
-                              Height="23"
-                              Data="M5.1163335,0C6.4203386,-9.1704351E-08,7.7243743,0.4009941,8.7273803,1.4039678L16.150495,8.1248624 23.27359,1.704927C25.27963,-0.10003502 28.489671,-0.10003502 30.495712,1.704927 32.502731,3.5109269 32.502731,6.4198744 30.495712,8.2258736L23.373596,14.745721 30.094705,20.864637C32.100749,22.670576 32.100749,25.579523 30.094705,27.385523 28.088663,29.190485 24.878623,29.190485 22.871604,27.385523L16.150495,21.26563 9.1293941,27.585531C7.122345,29.39147 3.9123056,29.39147 1.9062939,27.585531 -0.099748187,25.780569 -0.099748187,22.870584 1.9062939,21.065622L8.9283719,14.745721 1.5052868,7.9248535C-0.50176227,6.1188537 -0.50176227,3.2099065 1.5052868,1.4039678 2.5082927,0.50200556 3.8122978,-9.1704351E-08 5.1163335,0z"
-                              Fill="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
-                              RenderTransformOrigin="0.5,0.5"
-                              Stretch="Fill">
-                              <Path.RenderTransform>
-                                 <TransformGroup>
-                                    <TransformGroup.Children>
-                                       <RotateTransform Angle="5" />
-                                       <ScaleTransform ScaleX=".6" ScaleY=".6" />
-                                    </TransformGroup.Children>
-                                 </TransformGroup>
-                              </Path.RenderTransform>
-                           </Path>
-                        </Grid>
-                     </Button.Content>
-                  </Button>
+							<Button.Content>
+								<Grid>
+									<Grid Width="30" Height="25" Visibility="Collapsed" />
+									<Path Width="23" Height="23" Data="M5.1163335,0C6.4203386,-9.1704351E-08,7.7243743,0.4009941,8.7273803,1.4039678L16.150495,8.1248624 23.27359,1.704927C25.27963,-0.10003502 28.489671,-0.10003502 30.495712,1.704927 32.502731,3.5109269 32.502731,6.4198744 30.495712,8.2258736L23.373596,14.745721 30.094705,20.864637C32.100749,22.670576 32.100749,25.579523 30.094705,27.385523 28.088663,29.190485 24.878623,29.190485 22.871604,27.385523L16.150495,21.26563 9.1293941,27.585531C7.122345,29.39147 3.9123056,29.39147 1.9062939,27.585531 -0.099748187,25.780569 -0.099748187,22.870584 1.9062939,21.065622L8.9283719,14.745721 1.5052868,7.9248535C-0.50176227,6.1188537 -0.50176227,3.2099065 1.5052868,1.4039678 2.5082927,0.50200556 3.8122978,-9.1704351E-08 5.1163335,0z"
+									      Fill="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+									      RenderTransformOrigin="0.5,0.5" Stretch="Fill">
+										<Path.RenderTransform>
+											<TransformGroup>
+												<TransformGroup.Children>
+													<RotateTransform Angle="5" />
+													<ScaleTransform ScaleX=".6" ScaleY=".6" />
+												</TransformGroup.Children>
+											</TransformGroup>
+										</Path.RenderTransform>
+									</Path>
+								</Grid>
+							</Button.Content>
+						</Button>
 
-               </Grid>
-               <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" />
-            </StackPanel>
-         </Border>
-      </DataTemplate>
+					</Grid>
+					<Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" />
+				</StackPanel>
+			</Border>
+		</DataTemplate>
 
-   </UserControl.Resources>
+	</UserControl.Resources>
 
-   <ScrollViewer VerticalScrollBarVisibility="Auto">
-      <Grid Margin="10,20,0,0">
+	<ScrollViewer VerticalScrollBarVisibility="Auto">
+		<Grid Margin="10,20,0,0">
 
-         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-	        <RowDefinition Height="Auto" />
-         </Grid.RowDefinitions>
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+			</Grid.RowDefinitions>
 
-         <StackPanel>
+			<StackPanel>
 
-	         <!--! Line Spacing-->
-	         <GroupBox
-		         Grid.Row="0"
-		         Width="370"
-		         Padding="5,5,0,0"
-		         HorizontalAlignment="Left"
-		         BorderThickness="1.5"
-		         Header="Default Line Spacing">
+				<!--  ! Line Spacing  -->
+				<GroupBox Grid.Row="0" Width="370" Padding="5,5,0,0"
+				          HorizontalAlignment="Left" BorderThickness="1.5" Header="Default Line Spacing">
 
-		         <StackPanel Grid.Row="0" Margin="0,5,0,0">
+					<StackPanel Grid.Row="0" Margin="0,5,0,0">
 
-			         <!--! Amount of Line Spacing -->
-			         <StackPanel
-				         Margin="20,10"
-				         Orientation="Horizontal">
-				         <Slider
-					         x:Name="LineSpacingAmountSlider"
-					         Width="240"
-					         Height="30"
-					         IsSnapToTickEnabled="True"
-					         Maximum="1"
-					         Minimum="0"
-					         TickFrequency="0.05"
-					         TickPlacement="Both"
-					         Value="{Binding LineSpacing, Mode=TwoWay}" />
+						<!--  ! Amount of Line Spacing  -->
+						<StackPanel Margin="20,10" Orientation="Horizontal">
+							<Slider x:Name="LineSpacingAmountSlider" Width="240" Height="30"
+							        IsSnapToTickEnabled="True" Maximum="20" Minimum="0"
+							        TickFrequency="1" TickPlacement="Both"
+							        Value="{Binding LineSpacing, Mode=TwoWay}" />
 
-				         <TextBlock
-					         Padding="5,2"
-					         VerticalAlignment="Center"
-					         Style="{StaticResource DisabledTextBlock}"
-					         TextAlignment="Center">
+							<TextBlock Padding="5,2" VerticalAlignment="Center"
+							           Style="{StaticResource DisabledTextBlock}"
+							           TextAlignment="Center">
 
-					         <Run Text="{Binding Value, ElementName=LineSpacingAmountSlider}" /><Run Text="%" />
-				         </TextBlock>
+								<Run Text="{Binding Value, ElementName=LineSpacingAmountSlider}" /><Run Text=" Pixels" />
+							</TextBlock>
 
-			         </StackPanel>
-		         </StackPanel>
-	         </GroupBox>
+						</StackPanel>
+					</StackPanel>
+				</GroupBox>
 
 
-            <!--! Empty Lines Compression Controls-->
-            <GroupBox
-               Grid.Row="1"
-               Width="370"
-               Padding="5,5,0,0"
-               HorizontalAlignment="Left"
-               BorderThickness="1.5"
-               Header="Compress Empty Lines">
+				<!--  ! Empty Lines Compression Controls  -->
+				<GroupBox Grid.Row="1" Width="370" Padding="5,5,0,0"
+				          HorizontalAlignment="Left" BorderThickness="1.5" Header="Compress Empty Lines">
 
-               <StackPanel Grid.Row="0" Margin="0,5,0,0">
+					<StackPanel Grid.Row="0" Margin="0,5,0,0">
 
-                  <!--! Enable/Disable Empty Line Compression-->
-                  <ToggleButton
-                     x:Name="CompressEmptyLinesToggle"
-                     Height="20"
-                     HorizontalAlignment="Left"
-                     IsChecked="{Binding CompressEmptyLines, Mode=TwoWay}"
-                     Style="{StaticResource AnimatedSwitch}" />
+						<!--  ! Enable/Disable Empty Line Compression  -->
+						<ToggleButton x:Name="CompressEmptyLinesToggle" Height="20" HorizontalAlignment="Left"
+						              IsChecked="{Binding CompressEmptyLines, Mode=TwoWay}"
+						              Style="{StaticResource AnimatedSwitch}" />
 
 
-                  <!--! Empty Line Compression Rate-->
-                  <StackPanel
-                     Margin="20,10"
-                     IsEnabled="{Binding ElementName=CompressEmptyLinesToggle, Path=IsChecked}"
-                     Orientation="Horizontal">
-                     <Slider
-                        x:Name="EmptyLineCompressionRateSlider"
-                        Width="240"
-                        Height="30"
-                        IsSnapToTickEnabled="True"
-                        Maximum="95"
-                        Minimum="5"
-                        TickFrequency="5"
-                        TickPlacement="Both"
-                        Value="{Binding EmptyLineScale, Mode=TwoWay}" />
+						<!--  ! Empty Line Compression Rate  -->
+						<StackPanel Margin="20,10" IsEnabled="{Binding ElementName=CompressEmptyLinesToggle, Path=IsChecked}" Orientation="Horizontal">
+							<Slider x:Name="EmptyLineCompressionRateSlider" Width="240" Height="30"
+							        IsSnapToTickEnabled="True" Maximum="95" Minimum="5"
+							        TickFrequency="5" TickPlacement="Both"
+							        Value="{Binding EmptyLineScale, Mode=TwoWay}" />
 
-                     <TextBlock
-                        Padding="5,2"
-                        VerticalAlignment="Center"
-                        Style="{StaticResource DisabledTextBlock}"
-                        TextAlignment="Center">
+							<TextBlock Padding="5,2" VerticalAlignment="Center"
+							           Style="{StaticResource DisabledTextBlock}"
+							           TextAlignment="Center">
 
-                        <Run Text="{Binding Value, ElementName=EmptyLineCompressionRateSlider}" /><Run Text="% Smaller" />
-                     </TextBlock>
+								<Run Text="{Binding Value, ElementName=EmptyLineCompressionRateSlider}" /><Run Text="% Smaller" />
+							</TextBlock>
 
-                  </StackPanel>
-               </StackPanel>
-            </GroupBox>
+						</StackPanel>
+					</StackPanel>
+				</GroupBox>
 
 
-            <!--! Custom Tokens Compression Controls-->
-            <GroupBox
-               Grid.Row="2"
-               Width="370"
-               Margin="0,10,0,0"
-               Padding="5,5,0,0"
-               HorizontalAlignment="Left"
-               BorderThickness="1.5"
-               Header="Compress Lines With Specific Content">
-               <StackPanel Grid.Row="1" Margin="0,5,0,0">
+				<!--  ! Custom Tokens Compression Controls  -->
+				<GroupBox Grid.Row="2" Width="370" Margin="0,10,0,0"
+				          Padding="5,5,0,0" HorizontalAlignment="Left" BorderThickness="1.5"
+				          Header="Compress Lines With Specific Content">
+					<StackPanel Grid.Row="1" Margin="0,5,0,0">
 
-                  <!--! Enable/Disable Custom Tokens Compression-->
-                  <ToggleButton
-                     x:Name="CompressCustomTokensToggle"
-                     Height="20"
-                     HorizontalAlignment="Left"
-                     IsChecked="{Binding CompressCustomTokens, Mode=TwoWay}"
-                     Style="{StaticResource AnimatedSwitch}"
-                     ToolTip="Customize what lines you want to compress." />
+						<!--  ! Enable/Disable Custom Tokens Compression  -->
+						<ToggleButton x:Name="CompressCustomTokensToggle" Height="20" HorizontalAlignment="Left"
+						              IsChecked="{Binding CompressCustomTokens, Mode=TwoWay}"
+						              Style="{StaticResource AnimatedSwitch}"
+						              ToolTip="Customize what lines you want to compress." />
 
 
-                  <!--! Custom Tokens List-->
-                  <StackPanel
-                     Width="265"
-                     Margin="20,5,0,10"
-                     HorizontalAlignment="Left"
-                     IsEnabled="{Binding IsChecked, ElementName=CompressCustomTokensToggle}">
+						<!--  ! Custom Tokens List  -->
+						<StackPanel Width="265" Margin="20,5,0,10" HorizontalAlignment="Left"
+						            IsEnabled="{Binding IsChecked, ElementName=CompressCustomTokensToggle}">
 
-                     <!--! New Token-->
-                     <Label Content="Enter line content:" Foreground="#545353" />
+							<!--  ! New Token  -->
+							<Label Content="Enter line content:" Foreground="#545353" />
 
-                     <Border
-                        Margin="0,0,0,4"
-                        BorderBrush="LightGray"
-                        BorderThickness="1">
-                        <Grid Height="30">
-                           <Grid.ColumnDefinitions>
-                              <ColumnDefinition Width="*" />
-                              <ColumnDefinition Width="50" />
-                           </Grid.ColumnDefinitions>
+							<Border Margin="0,0,0,4" BorderBrush="LightGray" BorderThickness="1">
+								<Grid Height="30">
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="*" />
+										<ColumnDefinition Width="50" />
+									</Grid.ColumnDefinitions>
 
 
-                           <TextBox
-                              x:Name="NewTokenTextBox"
-                              Grid.Column="0"
-                              Padding="5,0"
-                              VerticalContentAlignment="Center"
-                              BorderThickness="0"
-                              CommandManager.PreviewExecuted="NewTokenTextBox_PreviewExecuted"
-                              ContextMenu="{x:Null}"
-                              FontSize="15"
-                              FontWeight="SemiBold"
-                              MaxLength="27"
-                              PreviewKeyDown="NewTokenTextBox_PreviewKeyDown"
-                              ToolTip="Insert your token here." />
+									<TextBox x:Name="NewTokenTextBox" Grid.Column="0" Padding="5,0"
+									         VerticalContentAlignment="Center" BorderThickness="0" CommandManager.PreviewExecuted="NewTokenTextBox_PreviewExecuted"
+									         ContextMenu="{x:Null}"
+									         FontSize="15" FontWeight="SemiBold" MaxLength="27"
+									         PreviewKeyDown="NewTokenTextBox_PreviewKeyDown" ToolTip="Insert your token here." />
 
 
-                           <Button
-                              x:Name="AddNewTokenButton"
-                              Grid.Column="1"
-                              Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=DataContext.InsertTokenCommand}"
-                              CommandParameter="{Binding ElementName=NewTokenTextBox, Path=Text}"
-                              Content="{StaticResource AddButtonIcon}"
-                              Cursor="Hand"
-                              Style="{StaticResource AddButton}" />
+									<Button x:Name="AddNewTokenButton" Grid.Column="1"
+									        Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=DataContext.InsertTokenCommand}"
+									        CommandParameter="{Binding ElementName=NewTokenTextBox, Path=Text}"
+									        Content="{StaticResource AddButtonIcon}"
+									        Cursor="Hand"
+									        Style="{StaticResource AddButton}" />
 
-                        </Grid>
-                     </Border>
+								</Grid>
+							</Border>
 
-                     <!--! Tokens List-->
-                     <Border
-                        Background="White"
-                        BorderBrush="LightGray"
-                        BorderThickness="1">
+							<!--  ! Tokens List  -->
+							<Border Background="White" BorderBrush="LightGray" BorderThickness="1">
 
-                        <ScrollViewer Height="100" VerticalScrollBarVisibility="Visible">
+								<ScrollViewer Height="100" VerticalScrollBarVisibility="Visible">
 
-                           <ItemsControl
-                              x:Name="CustomTokensList"
-                              ItemTemplate="{StaticResource TokenListItemTemplate}"
-                              ItemsSource="{Binding CustomTokens}"
-                              ScrollViewer.VerticalScrollBarVisibility="Visible" />
-                        </ScrollViewer>
-                     </Border>
-                  </StackPanel>
+									<ItemsControl x:Name="CustomTokensList"
+									              ItemTemplate="{StaticResource TokenListItemTemplate}"
+									              ItemsSource="{Binding CustomTokens}"
+									              ScrollViewer.VerticalScrollBarVisibility="Visible" />
+								</ScrollViewer>
+							</Border>
+						</StackPanel>
 
-                  <!--! Custom Tokens Compression Scale-->
-                  <StackPanel
-                     Margin="20,5,20,10"
-                     IsEnabled="{Binding IsChecked, ElementName=CompressCustomTokensToggle}"
-                     Orientation="Horizontal">
-                     <Slider
-                        x:Name="CustomTokensCompressionRateSlider"
-                        Width="240"
-                        Height="30"
-                        IsSnapToTickEnabled="True"
-                        Maximum="95"
-                        Minimum="5"
-                        TickFrequency="5"
-                        TickPlacement="Both"
-                        Value="{Binding CustomTokensScale, Mode=TwoWay}" />
+						<!--  ! Custom Tokens Compression Scale  -->
+						<StackPanel Margin="20,5,20,10" IsEnabled="{Binding IsChecked, ElementName=CompressCustomTokensToggle}" Orientation="Horizontal">
+							<Slider x:Name="CustomTokensCompressionRateSlider" Width="240" Height="30"
+							        IsSnapToTickEnabled="True" Maximum="95" Minimum="5"
+							        TickFrequency="5" TickPlacement="Both"
+							        Value="{Binding CustomTokensScale, Mode=TwoWay}" />
 
-                     <TextBlock
-                        Padding="5,2"
-                        VerticalAlignment="Center"
-                        Style="{StaticResource DisabledTextBlock}">
-                        <Run Text="{Binding Value, ElementName=CustomTokensCompressionRateSlider}" /><Run Text="% Smaller" />
-                     </TextBlock>
-                  </StackPanel>
+							<TextBlock Padding="5,2" VerticalAlignment="Center" Style="{StaticResource DisabledTextBlock}">
+								<Run Text="{Binding Value, ElementName=CustomTokensCompressionRateSlider}" /><Run Text="% Smaller" />
+							</TextBlock>
+						</StackPanel>
 
-               </StackPanel>
-            </GroupBox>
+					</StackPanel>
+				</GroupBox>
 
-         </StackPanel>
-      </Grid>
-   </ScrollViewer>
+			</StackPanel>
+		</Grid>
+	</ScrollViewer>
 
 </UserControl>

--- a/LinePress/Options/OptionsPageControl.xaml
+++ b/LinePress/Options/OptionsPageControl.xaml
@@ -250,6 +250,7 @@
 							</TextBlock>
 
 						</StackPanel>
+            <CheckBox IsChecked="{Binding ApplySpacingToComments, Mode=TwoWay}" Content="Apply spacing to comments"/>
 					</StackPanel>
 				</GroupBox>
 

--- a/LinePress/Options/OptionsPageControl.xaml
+++ b/LinePress/Options/OptionsPageControl.xaml
@@ -234,29 +234,34 @@
 				          HorizontalAlignment="Left" BorderThickness="1.5" Header="Default Line Spacing">
 
 					<StackPanel Grid.Row="0" Margin="0,5,0,0">
+						<StackPanel Margin="20,10" Orientation="Horizontal">
+							<RadioButton GroupName="Units" Content="pixel  " IsChecked="{Binding PixelSpacingUsed}" />
+							<RadioButton GroupName="Units" Content="em " IsChecked="{Binding EmSpacingUsed}" />
+						</StackPanel>
 
 						<!--  ! Amount of Line Spacing  -->
 						<StackPanel Margin="20,10" Orientation="Horizontal">
 							<Slider x:Name="LineSpacingAmountSlider" Width="240" Height="30"
-							        IsSnapToTickEnabled="True" Maximum="20" Minimum="0"
-							        TickFrequency="1" TickPlacement="Both"
+							        IsSnapToTickEnabled="True" Maximum="{Binding SpacingMaxValue, Mode=OneWay}" Minimum="0"
+							        TickFrequency="{Binding SpacingTickValue, Mode=OneWay}" TickPlacement="Both"
 							        Value="{Binding LineSpacing, Mode=TwoWay}" />
 
 							<TextBlock Padding="5,2" VerticalAlignment="Center"
 							           Style="{StaticResource DisabledTextBlock}"
 							           TextAlignment="Center">
 
-								<Run Text="{Binding Value, ElementName=LineSpacingAmountSlider}" /><Run Text=" Pixels" />
+								<Run Text="{Binding Value, ElementName=LineSpacingAmountSlider}" />
+								<Run Text="{Binding SpacingUnitLabel, Mode=OneWay}" />
 							</TextBlock>
 
 						</StackPanel>
-            <CheckBox IsChecked="{Binding ApplySpacingToComments, Mode=TwoWay}" Content="Apply spacing to comments"/>
+						<CheckBox IsChecked="{Binding ApplySpacingToComments, Mode=TwoWay}" Content="Apply spacing to comments"/>
 					</StackPanel>
 				</GroupBox>
 
 
 				<!--  ! Empty Lines Compression Controls  -->
-				<GroupBox Grid.Row="1" Width="370" Padding="5,5,0,0"
+				<GroupBox Grid.Row="1" Width="370" Margin="0,10,0,0" Padding="5,5,0,0"
 				          HorizontalAlignment="Left" BorderThickness="1.5" Header="Compress Empty Lines">
 
 					<StackPanel Grid.Row="0" Margin="0,5,0,0">

--- a/LinePress/Options/OptionsPageControl.xaml
+++ b/LinePress/Options/OptionsPageControl.xaml
@@ -1,8 +1,9 @@
 ﻿<UserControl x:Class="LinePress.Options.OptionsPageControl" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" Width="393"
-             Height="420" mc:Ignorable="d">
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:local="clr-namespace:LinePress.Options" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             Width="393" Height="420" mc:Ignorable="d">
 
 	<UserControl.Resources>
+		<local:BoolInverterConverter x:Key="BoolInverterConverter" />
 
 		<!--  ! Dim TextBlock when disabled  -->
 		<Style x:Key="DisabledTextBlock" TargetType="TextBlock">
@@ -235,15 +236,21 @@
 
 					<StackPanel Grid.Row="0" Margin="0,5,0,0">
 						<StackPanel Margin="20,10" Orientation="Horizontal">
-							<RadioButton GroupName="Units" Content="pixel  " IsChecked="{Binding PixelSpacingUsed}" />
-							<RadioButton GroupName="Units" Content="em " IsChecked="{Binding EmSpacingUsed}" />
+							<TextBlock Text="Units: " />
+							<RadioButton Margin="10,0,0,0" Content="pixel  " GroupName="Units"
+							             IsChecked="{Binding EmSpacingUsed, Converter={StaticResource BoolInverterConverter}}" />
+							<RadioButton Content="em " GroupName="Units" IsChecked="{Binding EmSpacingUsed}" />
+							<CheckBox Margin="25,0,0,0" Content="Comments too" IsChecked="{Binding ApplySpacingToComments, Mode=TwoWay}" />
 						</StackPanel>
 
 						<!--  ! Amount of Line Spacing  -->
 						<StackPanel Margin="20,10" Orientation="Horizontal">
 							<Slider x:Name="LineSpacingAmountSlider" Width="240" Height="30"
-							        IsSnapToTickEnabled="True" Maximum="{Binding SpacingMaxValue, Mode=OneWay}" Minimum="0"
-							        TickFrequency="{Binding SpacingTickValue, Mode=OneWay}" TickPlacement="Both"
+							        IsSnapToTickEnabled="True"
+							        Maximum="{Binding SpacingMaxValue, Mode=OneWay}"
+							        Minimum="0"
+							        TickFrequency="{Binding SpacingTickValue, Mode=OneWay}"
+							        TickPlacement="Both"
 							        Value="{Binding LineSpacing, Mode=TwoWay}" />
 
 							<TextBlock Padding="5,2" VerticalAlignment="Center"
@@ -255,14 +262,14 @@
 							</TextBlock>
 
 						</StackPanel>
-						<CheckBox IsChecked="{Binding ApplySpacingToComments, Mode=TwoWay}" Content="Apply spacing to comments"/>
 					</StackPanel>
 				</GroupBox>
 
 
 				<!--  ! Empty Lines Compression Controls  -->
-				<GroupBox Grid.Row="1" Width="370" Margin="0,10,0,0" Padding="5,5,0,0"
-				          HorizontalAlignment="Left" BorderThickness="1.5" Header="Compress Empty Lines">
+				<GroupBox Grid.Row="1" Width="370" Margin="0,10,0,0"
+				          Padding="5,5,0,0" HorizontalAlignment="Left" BorderThickness="1.5"
+				          Header="Compress Empty Lines">
 
 					<StackPanel Grid.Row="0" Margin="0,5,0,0">
 


### PR DESCRIPTION
Hi Omar,

for quite a while now I was looking for a way to change the line spacing / line height until I discovered your LinePress extension. I've added that as a feature on my fork under manfredk/LinePress and I wonder if you would include that into LinePress itself. It's only a quick hack for my own needs though.

Line-spacing seems to be quite wanted, see for example https://visualstudio.uservoice.com/forums/121579-visual-studio-ide/suggestions/6578993-line-spacing

#### Changes in this PR:
* added a group box for line spacing into the options dialog
* changed LinePressSettings to include the LineSpacing setting
* changed LinePressTransformSource to deliver DefaultTransform, EmptyLineTransform and CustomTokensTransform with bottomSpace set from LineSpacing

Additionally, I've added 3 lines to csproj, allowing to debug the extensions directly in devenv.

__Attention__: While editing OptionsPageControl.xaml I had automatic formatting on, so it reformatted and the diff is rather large. I've added an additional rowDefinition to the outer Stackpanel, a Groupbox in row 0 and changed the row-numbers of the other two.

#### Options dialog:
![linepress-options-new](https://user-images.githubusercontent.com/3963984/29428718-78cf062a-838e-11e7-9be7-d9eec7b7c92d.png)

#### Result (5 px line-spacing, no compression):
![image](https://user-images.githubusercontent.com/3963984/29429106-be78f018-838f-11e7-841e-9e404511c005.png)

Regards,
Manfred